### PR TITLE
Revert fixed REDAXO 5.11.0 version

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM friendsofredaxo/redaxo:5.11.0-php7.4-apache
+FROM friendsofredaxo/redaxo:5
 
 # copy custom setup script
 # will be executed within the REDAXO container once the REDAXO setup was finished

--- a/community/Dockerfile
+++ b/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM friendsofredaxo/redaxo:5.11.0-php7.4-apache
+FROM friendsofredaxo/redaxo:5
 
 # copy custom setup script
 # will be executed within the REDAXO container once the REDAXO setup was finished

--- a/onepage/Dockerfile
+++ b/onepage/Dockerfile
@@ -1,4 +1,4 @@
-FROM friendsofredaxo/redaxo:5.11.0-php7.4-apache
+FROM friendsofredaxo/redaxo:5
 
 # copy custom setup script
 # will be executed within the REDAXO container once the REDAXO setup was finished

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -1,4 +1,4 @@
-FROM friendsofredaxo/redaxo:5.11.0-php7.4-apache
+FROM friendsofredaxo/redaxo:5
 
 # copy custom setup script
 # will be executed within the REDAXO container once the REDAXO setup was finished


### PR DESCRIPTION
Mit 5.11.2 ist das Problem im Backup-AddOn behoben worden, dass die Demos nicht mehr installiert werden konnten. Deshalb können wir hier die festgesetzte Version wieder aufheben und wieder die neuste 5er anbieten.